### PR TITLE
[client] enable session redirect for guest login and signup

### DIFF
--- a/client/src/components/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute.jsx
@@ -1,7 +1,8 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export default function ProtectedRoute({ children }) {
+  const location = useLocation();
   const { user, loading } = useAuth();
 
   if (loading) {
@@ -13,7 +14,11 @@ export default function ProtectedRoute({ children }) {
   }
 
   if (!user) {
-    return <Navigate to="/login" replace />;
+    const sessionRedirectUrl = encodeURIComponent(location.pathname);
+
+    return (
+      <Navigate to={`/login?sessionRedirect=${sessionRedirectUrl}`} replace />
+    );
   }
 
   return children;

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import clsx from 'clsx';
 
 export default function Login() {
+  const location = useLocation();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -18,6 +19,12 @@ export default function Login() {
     } catch {
       setError('Invalid username or password');
     }
+  };
+
+  // preserve search params when navigating to signup
+  const signupLink = {
+    pathname: '/signup',
+    search: location.search,
   };
 
   return (
@@ -94,7 +101,7 @@ export default function Login() {
           <p className="text-gray-700">
             Don't have an account?{' '}
             <Link
-              to="/signup"
+              to={signupLink}
               className="font-medium text-blue-800 hover:text-blue-600"
             >
               Sign up

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import clsx from 'clsx';
 
 export default function Signup() {
+  const location = useLocation();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -24,6 +25,12 @@ export default function Signup() {
     } catch {
       setError('Username already exists or signup failed');
     }
+  };
+
+  // preserve search params when navigating to login
+  const loginLink = {
+    pathname: '/login',
+    search: location.search,
   };
 
   return (
@@ -121,7 +128,7 @@ export default function Signup() {
           <p className="text-gray-700">
             Already have an account?{' '}
             <Link
-              to="/login"
+              to={loginLink}
               className="font-medium text-blue-800 hover:text-blue-600"
             >
               Log in


### PR DESCRIPTION
- Add current url path as `sessionRedirect` param when redirect guest user to login/signup in `ProtectedRoutes`
- Consume `sessionRedirect` param in `AuthContext`, and redirect authed user to the url path if exists
- Passing `sessionRedirect` param when navigating between login and signup pages